### PR TITLE
initial changes

### DIFF
--- a/src/EC_OEM.h
+++ b/src/EC_OEM.h
@@ -94,7 +94,8 @@ class EC_OEM{
     float getProbeType(void);
     bool  setProbeType(float type);
 // calibration register
-    uint8_t getStatusCalibration(void);
+    //uint8_t getStatusCalibration(void);
+    uint8_t getStatusCalibration(int x);
     bool    clearCalibrationData(void);
     bool    setCalibration(uint8_t mode=DRY_CALIBRATION, float value=0);
 // temperature compensation


### PR DESCRIPTION
i2c write long had an infinite loop,
rewrote getstatuscalibration, header changed to reflect that,
rewrote setcalibration mode if statement because logic was incorrect,
getconductivity was returning salinity instead of conductivity